### PR TITLE
throughオプションのサポート

### DIFF
--- a/lib/image_flux/option.rb
+++ b/lib/image_flux/option.rb
@@ -82,6 +82,7 @@ class ImageFlux::Option
   end
   attribute :q, :integer, default: 75, aliases: %i[quality]
   attribute :o, :boolean, default: true, aliases: %i[optimize]
+  attribute :t, :string, default: nil, aliases: %i[through]
 
   attribute :sig, :nonescape_string, default: nil
 

--- a/spec/image_flux/option_spec.rb
+++ b/spec/image_flux/option_spec.rb
@@ -3,11 +3,11 @@
 require 'spec_helper'
 
 RSpec.describe ImageFlux::Option do
-  subject(:option) { described_class.new(width: 100, o: false, f: 'png', a: :crop) }
+  subject(:option) { described_class.new(width: 100, o: false, f: 'png', a: :crop, t: 'gif') }
 
   describe '#to_query' do
     subject(:to_query) { option.to_query }
 
-    it { is_expected.to eq('w=100,o=0,f=png,a=2') }
+    it { is_expected.to eq('w=100,o=0,f=png,a=2,t=gif') }
   end
 end


### PR DESCRIPTION
## 公式Image_Fluxの資料より

https://console.imageflux.jp/docs/image/conversion-parameters#through

GIF画像を加工せずに出すためにこのthroughオプションのサポートが必要。
